### PR TITLE
Raising onChange event if closing the search field cause the search t…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lightning-design-components",
-  "version": "1.5.109",
+  "version": "1.5.110",
   "description": "Salesforce Lightning Design System components built with React",
   "main": "lib/scripts/index.js",
   "directories": {

--- a/src/scripts/SearchButtonField.js
+++ b/src/scripts/SearchButtonField.js
@@ -87,6 +87,10 @@ export default class SearchButtonField extends React.Component {
   }
 
   onCancelClick() {
+    const shouldRaiseOnChangeEventWithoutValue = (this.props.onChange && this.state.value);
+    if (shouldRaiseOnChangeEventWithoutValue) {
+      this.props.onChange();
+    }
     this.collapseField();
     if (this.props.onCancel) this.props.onCancel();
     if (this.props.onClosed) this.props.onClosed();


### PR DESCRIPTION
…erm to change

This will allow developers to hook only to the onChange prop due to onCancel always triggered when the search is cancelled